### PR TITLE
Add view to split error class by error message

### DIFF
--- a/lib/sidekiq/undertaker/dead_job.rb
+++ b/lib/sidekiq/undertaker/dead_job.rb
@@ -27,7 +27,7 @@ module Sidekiq
         end
       end
 
-      attr_reader :job_class, :time_elapsed_since_failure, :error_class, :bucket_name, :job
+      attr_reader :job_class, :time_elapsed_since_failure, :error_class, :error_msg, :bucket_name, :job
 
       def initialize(args)
         @job                        = args.fetch(:job)
@@ -35,12 +35,14 @@ module Sidekiq
         @bucket_name                = args.fetch(:bucket_name)
         @job_class                  = args.fetch(:job_class, job.item["class"])
         @error_class                = args.fetch(:error_class, job.item["error_class"])
+        @error_msg                  = args.fetch(:error_message, job.item["error_message"])
       end
 
       def ==(other)
         job_class == other.job_class &&
           time_elapsed_since_failure == other.time_elapsed_since_failure &&
           error_class                == other.error_class &&
+          error_msg                  == other.error_msg &&
           bucket_name                == other.bucket_name &&
           job_eql?(other.job)
       end
@@ -48,7 +50,7 @@ module Sidekiq
 
       private
 
-      attr_writer :job_class, :time_elapsed_since_failure, :error_class, :bucket_name, :job
+      attr_writer :job_class, :time_elapsed_since_failure, :error_class, :error_message, :bucket_name, :job
 
       def job_eql?(other_job) # rubocop:disable Metrics/AbcSize
         job.jid == other_job.jid &&

--- a/lib/sidekiq/undertaker/job_distributor.rb
+++ b/lib/sidekiq/undertaker/job_distributor.rb
@@ -19,6 +19,10 @@ module Sidekiq
         group_by(:error_class)
       end
 
+      def group_by_error_msg
+        group_by(:error_msg)
+      end
+
       private
 
       def distribute

--- a/lib/sidekiq/undertaker/job_filter.rb
+++ b/lib/sidekiq/undertaker/job_filter.rb
@@ -7,7 +7,7 @@ module Sidekiq
     class JobFilter
       class << self
         def filter_dead_jobs(filters = {})
-          # filters can have keys in (job_class, error_class, bucket_name)
+          # filters can have keys in (job_class, error_class, error_msg, bucket_name)
           dead_jobs = []
           Sidekiq::Undertaker::DeadJob.for_each do |dead_job|
             filter_passed = true
@@ -26,7 +26,8 @@ module Sidekiq
           value.nil? ||
             total_dead_bucket?(filter, value) ||
             all_jobs?(filter, value) ||
-            all_errors?(filter, value)
+            all_errors?(filter, value) ||
+            all_error_msgs?(filter, value)
         end
 
         def total_dead_bucket?(filter, value)
@@ -39,6 +40,10 @@ module Sidekiq
 
         def all_errors?(filter, value)
           filter == "error_class" && value == "all"
+        end
+
+        def all_error_msgs?(filter, value)
+          filter == "error_msg" && value == "all"
         end
       end
     end

--- a/lib/sidekiq/undertaker/web_extension.rb
+++ b/lib/sidekiq/undertaker/web_extension.rb
@@ -15,25 +15,27 @@ module Sidekiq
         app.get "/undertaker/filter/:job_class/:bucket_name" do
           show_filter_by_job_class_bucket_name
         end
-
-        app.get "/undertaker/morgue/:job_class/:error_class/:bucket_name" do
-          show_undertaker_by_job_class_error_class_bucket_name
+        app.get "/undertaker/filter/:job_class/:error_class/:bucket_name" do
+          show_filter_by_job_class_error_class_bucket_name
+        end
+        app.get "/undertaker/morgue/:job_class/:error_class/:error_msg/:bucket_name" do
+          show_undertaker_by_job_class_error_class_error_msg_bucket_name
         end
 
         app.post "/undertaker/morgue" do
           post_undertaker
         end
 
-        app.post "/undertaker/morgue/:job_class/:error_class/:bucket_name/delete" do
-          post_undertaker_job_class_error_class_buckent_name_delete
+        app.post "/undertaker/morgue/:job_class/:error_class/:error_msg/:bucket_name/delete" do
+          post_undertaker_job_class_error_class_error_msg_bucket_name_delete
         end
 
-        app.post "/undertaker/morgue/:job_class/:error_class/:bucket_name/retry" do
-          post_undertaker_job_class_error_class_buckent_name_retry
+        app.post "/undertaker/morgue/:job_class/:error_class/:error_msg/:bucket_name/retry" do
+          post_undertaker_job_class_error_class_error_msg_bucket_name_retry
         end
 
-        app.post "/undertaker/morgue/:job_class/:error_class/:bucket_name/export" do
-          post_undertaker_job_class_error_class_buckent_name_export
+        app.post "/undertaker/morgue/:job_class/:error_class/:error_msg/:bucket_name/export" do
+          post_undertaker_job_class_error_class_error_msg_bucket_name_export
         end
 
         app.post "/undertaker/import_jobs" do

--- a/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_filter_page_is_called/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
+++ b/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_filter_page_is_called/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
@@ -177,7 +177,7 @@
   </thead>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/all/all/total_dead'> all</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/all/all/all/total_dead'> all</a></td>
         <td><a href='/sidekiq/undertaker/filter/all/total_dead'>4</a></td>
         <td><a href='/sidekiq/undertaker/filter/all/1_hour'>4</a></td>
         <td><a href='/sidekiq/undertaker/filter/all/3_hours'>0</a></td>
@@ -188,7 +188,7 @@
       </tr>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/total_dead'> HardWorker</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/all/total_dead'> HardWorker</a></td>
         <td><a href='/sidekiq/undertaker/filter/HardWorker/total_dead'>3</a></td>
         <td><a href='/sidekiq/undertaker/filter/HardWorker/1_hour'>3</a></td>
         <td><a href='/sidekiq/undertaker/filter/HardWorker/3_hours'>0</a></td>
@@ -199,7 +199,7 @@
       </tr>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker1/all/total_dead'> HardWorker1</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker1/all/all/total_dead'> HardWorker1</a></td>
         <td><a href='/sidekiq/undertaker/filter/HardWorker1/total_dead'>1</a></td>
         <td><a href='/sidekiq/undertaker/filter/HardWorker1/1_hour'>1</a></td>
         <td><a href='/sidekiq/undertaker/filter/HardWorker1/3_hours'>0</a></td>

--- a/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_job_classbucket_page_is_called/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
+++ b/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_job_classbucket_page_is_called/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
@@ -178,36 +178,36 @@
   </thead>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/total_dead'>all</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/total_dead'>3</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/1_hour'>3</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/3_hours'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/1_day'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/3_days'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/1_week'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/older'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/all/total_dead'>all</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/total_dead'>3</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/1_hour'>3</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/older'>0</a></td>
       </tr>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/total_dead'>RuntimeError</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/total_dead'>2</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/1_hour'>2</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/3_hours'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/1_day'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/3_days'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/1_week'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/older'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/all/total_dead'>RuntimeError</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/total_dead'>2</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/1_hour'>2</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/older'>0</a></td>
       </tr>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/total_dead'>NoMethodError</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/total_dead'>1</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/1_hour'>1</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/3_hours'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/1_day'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/3_days'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/1_week'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/older'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/all/total_dead'>NoMethodError</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/total_dead'>1</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/1_hour'>1</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/older'>0</a></td>
       </tr>
   
 </table>

--- a/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_job_classbucket_page_is_polled/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
+++ b/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_job_classbucket_page_is_polled/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
@@ -178,36 +178,36 @@
   </thead>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/total_dead'>all</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/total_dead'>3</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/1_hour'>3</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/3_hours'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/1_day'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/3_days'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/1_week'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/older'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/all/all/total_dead'>all</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/total_dead'>3</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/1_hour'>3</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/all/older'>0</a></td>
       </tr>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/total_dead'>RuntimeError</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/total_dead'>2</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/1_hour'>2</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/3_hours'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/1_day'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/3_days'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/1_week'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/older'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/all/total_dead'>RuntimeError</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/total_dead'>2</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/1_hour'>2</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/RuntimeError/older'>0</a></td>
       </tr>
   
       <tr>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/total_dead'>NoMethodError</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/total_dead'>1</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/1_hour'>1</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/3_hours'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/1_day'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/3_days'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/1_week'>0</a></td>
-        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/older'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/NoMethodError/all/total_dead'>NoMethodError</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/total_dead'>1</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/1_hour'>1</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/filter/HardWorker/NoMethodError/older'>0</a></td>
       </tr>
   
 </table>

--- a/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_job_classerror_classbucket_page_is_called/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
+++ b/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_job_classerror_classbucket_page_is_called/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
@@ -86,7 +86,7 @@
         
 
         
-          <li class="" data-navbar="custom-tab">
+          <li class="active" data-navbar="custom-tab">
             <a href="/sidekiq/undertaker/filter">Undertaker</a>
           </li>
         
@@ -154,106 +154,53 @@
           </div>
 
           <div class="col-sm-12">
-            <header class="row head">
+            <header class="row header">
   <div class="col-sm-12">
     <h3>
       <b>2</b> dead jobs
        of <b>HardWorker</b> class
        with <b>RuntimeError</b> exception
-      
-       in <b>1_hour</b> bucket
     </h3>
-  </div>
-  <div class="col-sm-12">
-    <div class="col-sm-4">
-      
-
-    </div>
   </div>
 </header>
 
-
-    <form action="/sidekiq/undertaker/morgue" method="post">
-      <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
-      <table class="table table-striped table-bordered table-white">
-        <thead>
-          <tr>
-            <th width="20px" class="table-checkbox">
-              <label>
-                <input type="checkbox" class="check_all" />
-              </label>
-            </th>
-            <th width="25%">Last Retry</th>
-            <th>Queue</th>
-            <th>Job</th>
-            <th>Arguments</th>
-            <th>Error</th>
-          </tr>
-        </thead>
-        
-          <tr>
-            <td class="table-checkbox">
-              <label>
-                <input type='checkbox' name='key[]' value='1544993820.0-4416aa76eb8cf03f56a49220' />
-              </label>
-            </td>
-            <td>
-              <a href="/sidekiq/morgue/1544993820.0-4416aa76eb8cf03f56a49220"><time class="ltr" dir="ltr" title="2018-12-16T20:57:00Z" datetime="2018-12-16T20:57:00Z">2018-12-16 20:57:00 UTC</time></a>
-            </td>
-            <td>
-              <a href="/sidekiq/queues/foo">foo</a>
-            </td>
-            <td>HardWorker</td>
-            <td>
-              <div class="args">&quot;asdf&quot;, 1234</div>
-            </td>
-            <td>
-              <div>RuntimeError: Option &#x27;data&#x2F;file_name&#x27; is required</div>
-            </td>
-          </tr>
-        
-          <tr>
-            <td class="table-checkbox">
-              <label>
-                <input type='checkbox' name='key[]' value='1544993820.0-34e79a46b1956d3a1180767b' />
-              </label>
-            </td>
-            <td>
-              <a href="/sidekiq/morgue/1544993820.0-34e79a46b1956d3a1180767b"><time class="ltr" dir="ltr" title="2018-12-16T20:57:00Z" datetime="2018-12-16T20:57:00Z">2018-12-16 20:57:00 UTC</time></a>
-            </td>
-            <td>
-              <a href="/sidekiq/queues/foo">foo</a>
-            </td>
-            <td>HardWorker</td>
-            <td>
-              <div class="args">&quot;asdf&quot;, 1234</div>
-            </td>
-            <td>
-              <div>RuntimeError: Option &#x27;data&#x2F;file_name&#x27; is required</div>
-            </td>
-          </tr>
-        
-      </table>
-      <input class="btn btn-primary btn-xs pull-left" type="submit" name="retry" value="Revive" />
-      <input class="btn btn-secondary btn-xs pull-left" type="submit" name="export" value="Export" />
-      <input class="btn btn-danger btn-xs pull-left" type="submit" name="delete" value="Bury" />
-    </form>
-
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/delete" method="post">
-      <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
-      <input class="btn btn-danger btn-xs pull-right" type="submit" name="delete" value="Bury All" data-confirm="Are you sure?" />
-    </form>
-
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/export" method="post">
-      <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
-      <input class="btn btn-secondary btn-xs pull-right" type="submit" name="export" value="Export All" />
-    </form>
-
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/retry" method="post">
-      <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
-      <input class="btn btn-danger btn-xs pull-right" type="submit" name="retry" value="Revive All" data-confirm="Are you sure?" />
-    </form>
-
+<table class="table table-striped table-bordered table-white">
+  <thead>
+    <tr>
+      <th style="width: 20%">Error Message</th>
+      <th style="width: 10%">All</th>
+      <th style="width: 10%">1 hour</th>
+      <th style="width: 10%">3 hours</th>
+      <th style="width: 10%">1 day</th>
+      <th style="width: 10%">3 days</th>
+      <th style="width: 10%">1 week</th>
+      <th style="width: 10%">Older</th>
+    </tr>
+  </thead>
+  
+      <tr>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/total_dead'>Option 'data/file_name' is required</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/total_dead'>2</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_hour'>2</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/older'>0</a></td>
+      </tr>
+  
+      <tr>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/total_dead'>all</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/total_dead'>2</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour'>2</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/older'>0</a></td>
+      </tr>
+  
+</table>
 
           </div>
         </div>

--- a/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_job_classerror_classbucket_page_is_polled/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
+++ b/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_filter/when_job_classerror_classbucket_page_is_polled/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
@@ -86,7 +86,7 @@
         
 
         
-          <li class="" data-navbar="custom-tab">
+          <li class="active" data-navbar="custom-tab">
             <a href="/sidekiq/undertaker/filter">Undertaker</a>
           </li>
         
@@ -154,106 +154,53 @@
           </div>
 
           <div class="col-sm-12">
-            <header class="row head">
+            <header class="row header">
   <div class="col-sm-12">
     <h3>
       <b>2</b> dead jobs
        of <b>HardWorker</b> class
        with <b>RuntimeError</b> exception
-      
-       in <b>1_hour</b> bucket
     </h3>
-  </div>
-  <div class="col-sm-12">
-    <div class="col-sm-4">
-      
-
-    </div>
   </div>
 </header>
 
-
-    <form action="/sidekiq/undertaker/morgue" method="post">
-      <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
-      <table class="table table-striped table-bordered table-white">
-        <thead>
-          <tr>
-            <th width="20px" class="table-checkbox">
-              <label>
-                <input type="checkbox" class="check_all" />
-              </label>
-            </th>
-            <th width="25%">Last Retry</th>
-            <th>Queue</th>
-            <th>Job</th>
-            <th>Arguments</th>
-            <th>Error</th>
-          </tr>
-        </thead>
-        
-          <tr>
-            <td class="table-checkbox">
-              <label>
-                <input type='checkbox' name='key[]' value='1544993820.0-4416aa76eb8cf03f56a49220' />
-              </label>
-            </td>
-            <td>
-              <a href="/sidekiq/morgue/1544993820.0-4416aa76eb8cf03f56a49220"><time class="ltr" dir="ltr" title="2018-12-16T20:57:00Z" datetime="2018-12-16T20:57:00Z">2018-12-16 20:57:00 UTC</time></a>
-            </td>
-            <td>
-              <a href="/sidekiq/queues/foo">foo</a>
-            </td>
-            <td>HardWorker</td>
-            <td>
-              <div class="args">&quot;asdf&quot;, 1234</div>
-            </td>
-            <td>
-              <div>RuntimeError: Option &#x27;data&#x2F;file_name&#x27; is required</div>
-            </td>
-          </tr>
-        
-          <tr>
-            <td class="table-checkbox">
-              <label>
-                <input type='checkbox' name='key[]' value='1544993820.0-34e79a46b1956d3a1180767b' />
-              </label>
-            </td>
-            <td>
-              <a href="/sidekiq/morgue/1544993820.0-34e79a46b1956d3a1180767b"><time class="ltr" dir="ltr" title="2018-12-16T20:57:00Z" datetime="2018-12-16T20:57:00Z">2018-12-16 20:57:00 UTC</time></a>
-            </td>
-            <td>
-              <a href="/sidekiq/queues/foo">foo</a>
-            </td>
-            <td>HardWorker</td>
-            <td>
-              <div class="args">&quot;asdf&quot;, 1234</div>
-            </td>
-            <td>
-              <div>RuntimeError: Option &#x27;data&#x2F;file_name&#x27; is required</div>
-            </td>
-          </tr>
-        
-      </table>
-      <input class="btn btn-primary btn-xs pull-left" type="submit" name="retry" value="Revive" />
-      <input class="btn btn-secondary btn-xs pull-left" type="submit" name="export" value="Export" />
-      <input class="btn btn-danger btn-xs pull-left" type="submit" name="delete" value="Bury" />
-    </form>
-
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/delete" method="post">
-      <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
-      <input class="btn btn-danger btn-xs pull-right" type="submit" name="delete" value="Bury All" data-confirm="Are you sure?" />
-    </form>
-
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/export" method="post">
-      <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
-      <input class="btn btn-secondary btn-xs pull-right" type="submit" name="export" value="Export All" />
-    </form>
-
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/retry" method="post">
-      <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
-      <input class="btn btn-danger btn-xs pull-right" type="submit" name="retry" value="Revive All" data-confirm="Are you sure?" />
-    </form>
-
+<table class="table table-striped table-bordered table-white">
+  <thead>
+    <tr>
+      <th style="width: 20%">Error Message</th>
+      <th style="width: 10%">All</th>
+      <th style="width: 10%">1 hour</th>
+      <th style="width: 10%">3 hours</th>
+      <th style="width: 10%">1 day</th>
+      <th style="width: 10%">3 days</th>
+      <th style="width: 10%">1 week</th>
+      <th style="width: 10%">Older</th>
+    </tr>
+  </thead>
+  
+      <tr>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/total_dead'>Option 'data/file_name' is required</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/total_dead'>2</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_hour'>2</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/older'>0</a></td>
+      </tr>
+  
+      <tr>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/total_dead'>all</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/total_dead'>2</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour'>2</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/3_hours'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_day'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/3_days'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_week'>0</a></td>
+        <td><a href='/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/older'>0</a></td>
+      </tr>
+  
+</table>
 
           </div>
         </div>

--- a/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_morgue/when_job_classerrorbucket_is_called/with_all_failures_and_errors/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
+++ b/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_morgue/when_job_classerrorbucket_is_called/with_all_failures_and_errors/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
@@ -160,6 +160,7 @@
       <b>4</b> dead jobs
       
       
+      
        in <b>total_dead</b> bucket
     </h3>
   </div>
@@ -207,7 +208,7 @@
               <div class="args">&quot;asdf&quot;, 1234</div>
             </td>
             <td>
-              <div>NoMethodError: Some fake message</div>
+              <div>NoMethodError: Option &#x27;data&#x2F;file_name&#x27; is required</div>
             </td>
           </tr>
         
@@ -228,7 +229,7 @@
               <div class="args">&quot;asdf&quot;, 1234</div>
             </td>
             <td>
-              <div>RuntimeError: Some fake message</div>
+              <div>RuntimeError: Option &#x27;data&#x2F;file_name&#x27; is required</div>
             </td>
           </tr>
         
@@ -249,7 +250,7 @@
               <div class="args">&quot;asdf&quot;, 1234</div>
             </td>
             <td>
-              <div>RuntimeError: Some fake message</div>
+              <div>RuntimeError: Option &#x27;data&#x2F;file_name&#x27; is required</div>
             </td>
           </tr>
         
@@ -270,7 +271,7 @@
               <div class="args">&quot;asdf&quot;, 1234</div>
             </td>
             <td>
-              <div>NoMethodError: Some fake message</div>
+              <div>NoMethodError: Option &#x27;data&#x2F;file_name&#x27; is required</div>
             </td>
           </tr>
         
@@ -280,17 +281,17 @@
       <input class="btn btn-danger btn-xs pull-left" type="submit" name="delete" value="Bury" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/all/all/total_dead/delete" method="post">
+    <form action="/sidekiq/undertaker/morgue/all/all/YWxs/total_dead/delete" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-danger btn-xs pull-right" type="submit" name="delete" value="Bury All" data-confirm="Are you sure?" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/all/all/total_dead/export" method="post">
+    <form action="/sidekiq/undertaker/morgue/all/all/YWxs/total_dead/export" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-secondary btn-xs pull-right" type="submit" name="export" value="Export All" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/all/all/total_dead/retry" method="post">
+    <form action="/sidekiq/undertaker/morgue/all/all/YWxs/total_dead/retry" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-danger btn-xs pull-right" type="submit" name="retry" value="Revive All" data-confirm="Are you sure?" />
     </form>

--- a/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_morgue/when_job_classerrorbucket_is_called/with_specific_job_class_specific_error_and_specific_error_message/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
+++ b/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_morgue/when_job_classerrorbucket_is_called/with_specific_job_class_specific_error_and_specific_error_message/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
@@ -160,7 +160,7 @@
       <b>2</b> dead jobs
        of <b>HardWorker</b> class
        with <b>RuntimeError</b> exception
-      
+       with <b>Option 'data/file_name' is required</b> message
        in <b>1_hour</b> bucket
     </h3>
   </div>
@@ -239,17 +239,17 @@
       <input class="btn btn-danger btn-xs pull-left" type="submit" name="delete" value="Bury" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/delete" method="post">
+    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_hour/delete" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-danger btn-xs pull-right" type="submit" name="delete" value="Bury All" data-confirm="Are you sure?" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/export" method="post">
+    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_hour/export" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-secondary btn-xs pull-right" type="submit" name="export" value="Export All" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/retry" method="post">
+    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_hour/retry" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-danger btn-xs pull-right" type="submit" name="retry" value="Revive All" data-confirm="Are you sure?" />
     </form>

--- a/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_morgue/when_job_classerrorbucket_is_called/with_specific_job_class_specific_error_and_specific_error_message/with_pagination/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
+++ b/spec/fixtures/approvals/sidekiq_undertaker_webextension/show_morgue/when_job_classerrorbucket_is_called/with_specific_job_class_specific_error_and_specific_error_message/with_pagination/behaves_like_a_page/the_displayed_page_is_correct_for_sidekiqv6.approved.txt
@@ -160,7 +160,7 @@
       <b>52</b> dead jobs
        of <b>HardWorker</b> class
        with <b>RuntimeError</b> exception
-      
+       with <b>Option 'data/file_name' is required</b> message
        in <b>1_hour</b> bucket
     </h3>
   </div>
@@ -1265,17 +1265,17 @@
       <input class="btn btn-danger btn-xs pull-left" type="submit" name="delete" value="Bury" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/delete" method="post">
+    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_hour/delete" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-danger btn-xs pull-right" type="submit" name="delete" value="Bury All" data-confirm="Are you sure?" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/export" method="post">
+    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_hour/export" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-secondary btn-xs pull-right" type="submit" name="export" value="Export All" />
     </form>
 
-    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/YWxs/1_hour/retry" method="post">
+    <form action="/sidekiq/undertaker/morgue/HardWorker/RuntimeError/T3B0aW9uICdkYXRhL2ZpbGVfbmFtZScgaXMgcmVxdWlyZWQ=/1_hour/retry" method="post">
       <input type='hidden' name='authenticity_token' value='stubbed-csrf-token'/>
       <input class="btn btn-danger btn-xs pull-right" type="submit" name="retry" value="Revive All" data-confirm="Are you sure?" />
     </form>

--- a/spec/sidekiq/undertaker/dead_jobs_spec.rb
+++ b/spec/sidekiq/undertaker/dead_jobs_spec.rb
@@ -7,10 +7,11 @@ module Sidekiq
     describe DeadJob do
       let(:job) do
         build_job(
-          "class"       => "HardWorkTask",
-          "failed_at"   => Time.now,
-          "error_class" => "NoMethodError",
-          "queue"       => "SomeQueue"
+          "class"         => "HardWorkTask",
+          "failed_at"     => Time.now,
+          "error_class"   => "NoMethodError",
+          "queue"         => "SomeQueue",
+          "error_message" => "undefined method `pause` for HardWork:Class"
         )
       end
 
@@ -20,6 +21,7 @@ module Sidekiq
             job_class:                  "HardWorkTask",
             time_elapsed_since_failure: 9,
             error_class:                "NoMethodError",
+            error_msg:                  "undefined method `pause` for HardWork:Class",
             bucket_name:                "1_hour",
             job:                        job
           }
@@ -54,6 +56,7 @@ module Sidekiq
             job_class:                  "HardWorkTask",
             time_elapsed_since_failure: time_elapsed,
             error_class:                "NoMethodError",
+            error_msg:                  "undefined method `pause` for HardWork:Class",
             bucket_name:                "1_hour",
             job:                        killed_job
           )

--- a/spec/sidekiq/undertaker/job_distributor_spec.rb
+++ b/spec/sidekiq/undertaker/job_distributor_spec.rb
@@ -3,40 +3,45 @@
 require "spec_helper"
 
 module Sidekiq
+  # rubocop:disable Metrics/ModuleLength
   module Undertaker
     describe JobDistributor do
       let(:job1) do
         instance_double(Sidekiq::JobRecord, item: {
-                          "class"       => "A",
-                          "failed_at"   => 1,
-                          "error_class" => "E1"
+                          "class"         => "A",
+                          "failed_at"     => 1,
+                          "error_class"   => "E1",
+                          "error_message" => "M1"
                         })
       end
       let(:job2) do
         instance_double(Sidekiq::JobRecord, item: {
-                          "class"       => "A",
-                          "failed_at"   => 1,
-                          "error_class" => "E1"
+                          "class"         => "A",
+                          "failed_at"     => 1,
+                          "error_class"   => "E1",
+                          "error_message" => "M1"
                         })
       end
       let(:job3) do
         instance_double(Sidekiq::JobRecord, item: {
-                          "class"       => "B",
-                          "failed_at"   => 1,
-                          "error_class" => "E1"
+                          "class"         => "B",
+                          "failed_at"     => 1,
+                          "error_class"   => "E1",
+                          "error_message" => "M2"
                         })
       end
       let(:job4) do
         instance_double(Sidekiq::JobRecord, item: {
-                          "class"       => "B",
-                          "failed_at"   => 1,
-                          "error_class" => "E2"
+                          "class"         => "B",
+                          "failed_at"     => 1,
+                          "error_class"   => "E2",
+                          "error_message" => "M1"
                         })
       end
 
       let(:dead_job1) do
         DeadJob.new(
-          job:                        job1, # 'A', 'E1'
+          job:                        job1, # 'A', 'E1', 'M1'
           time_elapsed_since_failure: 10,
           bucket_name:                "1_hour"
         )
@@ -44,21 +49,21 @@ module Sidekiq
 
       let(:dead_job2) do
         DeadJob.new(
-          job:                        job2, # 'A', 'E1'
+          job:                        job2, # 'A', 'E1', 'M1'
           time_elapsed_since_failure: 10 + (60 * 60),
           bucket_name:                "3_hours"
         )
       end
       let(:dead_job3) do
         DeadJob.new(
-          job:                        job3, # 'B', 'E1'
+          job:                        job3, # 'B', 'E1', 'M2'
           time_elapsed_since_failure: 10 + (60 * 60),
           bucket_name:                "3_hours"
         )
       end
       let(:dead_job4) do
         DeadJob.new(
-          job:                        job4, # 'B', 'E2'
+          job:                        job4, # 'B', 'E2', 'M1'
           time_elapsed_since_failure: 10 + (60 * 60 * 24),
           bucket_name:                "1_day"
         )
@@ -98,7 +103,24 @@ module Sidekiq
           expect(distribution).to eq expected_distribution
         end
       end
+
+      describe "#group_by_error_msg" do
+        subject(:distribution) { described_class.new(dead_jobs).group_by_error_msg }
+
+        let(:expected_distribution) do
+          [
+            ["all", { "1_hour" => 1, "3_hours" => 2, "1_day" => 1,  "3_days" => 0, "1_week" => 0, "older" => 0, "total_dead" => 4 }],
+            ["M1",  { "1_hour" => 1, "3_hours" => 1, "1_day" => 1,  "3_days" => 0, "1_week" => 0, "older" => 0, "total_dead" => 3 }],
+            ["M2",  { "1_hour" => 0, "3_hours" => 1, "1_day" => 0,  "3_days" => 0, "1_week" => 0, "older" => 0, "total_dead" => 1 }]
+          ]
+        end
+
+        it "distributes the dead jobs into buckets and groups them by error_msg" do
+          expect(distribution).to eq expected_distribution
+        end
+      end
       # rubocop:enable Layout/LineLength
     end
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/web/views/filter.erb
+++ b/web/views/filter.erb
@@ -21,7 +21,7 @@
   </thead>
   <% @distribution.each do |group, bucket_counts| %>
       <tr>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{group}/all/total_dead" %>'> <%= group %></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{group}/all/all/total_dead" %>'> <%= group %></a></td>
         <td><a href='<%= "#{root_path}undertaker/filter/#{group}/total_dead" %>'><%= bucket_counts['total_dead']%></a></td>
         <td><a href='<%= "#{root_path}undertaker/filter/#{group}/1_hour" %>'><%= bucket_counts['1_hour']%></a></td>
         <td><a href='<%= "#{root_path}undertaker/filter/#{group}/3_hours" %>'><%= bucket_counts['3_hours']%></a></td>

--- a/web/views/filter_job_class.erb
+++ b/web/views/filter_job_class.erb
@@ -22,14 +22,14 @@
   </thead>
   <% @distribution.each do |group, bucket_counts| %>
       <tr>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/total_dead" %>'><%= group %></a></td>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/total_dead" %>'><%= bucket_counts['total_dead'] %></a></td>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/1_hour" %>'><%= bucket_counts['1_hour']%></a></td>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/3_hours" %>'><%= bucket_counts['3_hours']%></a></td>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/1_day" %>'><%= bucket_counts['1_day']%></a></td>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/3_days" %>'><%= bucket_counts['3_days']%></a></td>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/1_week" %>'><%= bucket_counts['1_week']%></a></td>
-        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/older" %>'><%= bucket_counts['older']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{group}/all/total_dead" %>'><%= group %></a></td>
+        <td><a href='<%= "#{root_path}undertaker/filter/#{@req_job_class}/#{group}/total_dead" %>'><%= bucket_counts['total_dead'] %></a></td>
+        <td><a href='<%= "#{root_path}undertaker/filter/#{@req_job_class}/#{group}/1_hour" %>'><%= bucket_counts['1_hour']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/filter/#{@req_job_class}/#{group}/3_hours" %>'><%= bucket_counts['3_hours']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/filter/#{@req_job_class}/#{group}/1_day" %>'><%= bucket_counts['1_day']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/filter/#{@req_job_class}/#{group}/3_days" %>'><%= bucket_counts['3_days']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/filter/#{@req_job_class}/#{group}/1_week" %>'><%= bucket_counts['1_week']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/filter/#{@req_job_class}/#{group}/older" %>'><%= bucket_counts['older']%></a></td>
       </tr>
   <% end %>
 </table>

--- a/web/views/filter_job_class_error_class.erb
+++ b/web/views/filter_job_class_error_class.erb
@@ -1,0 +1,36 @@
+<header class="row header">
+  <div class="col-sm-12">
+    <h3>
+      <%= "<b>#{@total_dead}</b> dead #{@total_dead == 1 ? 'job' : 'jobs'}" %>
+      <%= " of <b>#{@req_job_class}</b> class" unless @req_job_class == "all" %>
+      <%= " with <b>#{@req_error_class}</b> exception" unless @req_error_class == "all" %>
+    </h3>
+  </div>
+</header>
+
+<table class="table table-striped table-bordered table-white">
+  <thead>
+    <tr>
+      <th style="width: 20%"><%= t('Error Message') %></th>
+      <th style="width: 10%"><%= t('All') %></th>
+      <th style="width: 10%"><%= t('1 hour') %></th>
+      <th style="width: 10%"><%= t('3 hours') %></th>
+      <th style="width: 10%"><%= t('1 day') %></th>
+      <th style="width: 10%"><%= t('3 days') %></th>
+      <th style="width: 10%"><%= t('1 week') %></th>
+      <th style="width: 10%"><%= t('Older') %></th>
+    </tr>
+  </thead>
+  <% @distribution.each do |group, bucket_counts| %>
+      <tr>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(group)}/total_dead" %>'><%= group %></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(group)}/total_dead" %>'><%= bucket_counts['total_dead'] %></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(group)}/1_hour" %>'><%= bucket_counts['1_hour']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(group)}/3_hours" %>'><%= bucket_counts['3_hours']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(group)}/1_day" %>'><%= bucket_counts['1_day']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(group)}/3_days" %>'><%= bucket_counts['3_days']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(group)}/1_week" %>'><%= bucket_counts['1_week']%></a></td>
+        <td><a href='<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(group)}/older" %>'><%= bucket_counts['older']%></a></td>
+      </tr>
+  <% end %>
+</table>

--- a/web/views/morgue.erb
+++ b/web/views/morgue.erb
@@ -4,6 +4,7 @@
       <%= "<b>#{@total_dead}</b> dead #{@total_dead == 1 ? 'job' : 'jobs'}" %>
       <%= " of <b>#{@req_job_class}</b> class" unless @req_job_class == "all" %>
       <%= " with <b>#{@req_error_class}</b> exception" unless @req_error_class == "all" %>
+      <%= " with <b>#{@req_error_msg}</b> message" unless @req_error_msg == "all" %>
       <%= " in <b>#{@req_bucket_name}</b> bucket"  %>
     </h3>
   </div>
@@ -60,17 +61,17 @@
       <input class="btn btn-danger btn-xs pull-left" type="submit" name="delete" value="<%= t('UndertakerBury') %>" />
     </form>
 
-    <form action="<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{@req_bucket_name}/delete" %>" method="post">
+    <form action="<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(@req_error_msg)}/#{@req_bucket_name}/delete" %>" method="post">
       <%= respond_to?(:csrf_tag) && csrf_tag %>
       <input class="btn btn-danger btn-xs pull-right" type="submit" name="delete" value="<%= t('UndertakerBuryAll') %>" data-confirm="<%= t('AreYouSure') %>" />
     </form>
 
-    <form action="<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{@req_bucket_name}/export" %>" method="post">
+    <form action="<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(@req_error_msg)}/#{@req_bucket_name}/export" %>" method="post">
       <%= respond_to?(:csrf_tag) && csrf_tag %>
       <input class="btn btn-secondary btn-xs pull-right" type="submit" name="export" value="<%= t('UndertakerExportAll') %>" />
     </form>
 
-    <form action="<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{@req_bucket_name}/retry" %>" method="post">
+    <form action="<%= "#{root_path}undertaker/morgue/#{@req_job_class}/#{@req_error_class}/#{Base64.urlsafe_encode64(@req_error_msg)}/#{@req_bucket_name}/retry" %>" method="post">
       <%= respond_to?(:csrf_tag) && csrf_tag %>
       <input class="btn btn-danger btn-xs pull-right" type="submit" name="retry" value="<%= t('UndertakerReviveAll') %>" data-confirm="<%= t('AreYouSure') %>" />
     </form>


### PR DESCRIPTION
These changes enables users of this gem to split dead jobs further by drilling down to error messages, after they selected a job class and error class.

As the error message can contain any characters, it will be encoded in the URLs. Base64 encoding was chosen because Sinatra automatically decode url-encoded "/" before routing which leads to 404s (unless globally disables but that didn't seem like a secure option).