### PR TITLE
Fix rubocop dependency

### DIFF
--- a/sidekiq-undertaker.gemspec
+++ b/sidekiq-undertaker.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-mocks", "~> 3.8"
   spec.add_development_dependency "rspec-sidekiq", "~> 3.0"
   spec.add_development_dependency "rt_rubocop_defaults", "~> 2.3"
-  spec.add_development_dependency "rubocop", "~> 1.30"
+  spec.add_development_dependency "rubocop", "~> 1.28"
   spec.add_development_dependency "rubocop-rake", "~> 0.5"
   spec.add_development_dependency "rubocop-rspec", "~> 2.0"
   spec.add_development_dependency "rubocop_runner", "~> 2.1"


### PR DESCRIPTION
Fix downgrade rubocop to `1.28` to keep support for JRuby `9.2.20.1`