### PR TITLE
Make max error message length configurable

### DIFF
--- a/lib/sidekiq/undertaker.rb
+++ b/lib/sidekiq/undertaker.rb
@@ -14,3 +14,19 @@ if defined?(Sidekiq::Web)
   Sidekiq::Web.tabs["Undertaker"] = "undertaker/filter"
   Sidekiq::Web.settings.locales << File.join(File.dirname(__FILE__), "../../web/locales")
 end
+
+module Sidekiq
+  module Undertaker
+    @config = {
+      max_error_msg_length: 30
+    }
+
+    def self.max_error_msg_length=(value)
+      @config[:max_error_msg_length] = Integer(value)
+    end
+
+    def self.max_error_msg_length
+      @config[:max_error_msg_length]
+    end
+  end
+end

--- a/lib/sidekiq/undertaker/dead_job.rb
+++ b/lib/sidekiq/undertaker/dead_job.rb
@@ -53,7 +53,7 @@ module Sidekiq
       attr_writer :job_class, :time_elapsed_since_failure, :error_class, :error_message, :bucket_name, :job
 
       def shorten_error_msg(msg)
-        max_error_msg_length = 30
+        max_error_msg_length = Sidekiq::Undertaker.max_error_msg_length
 
         msg.length > max_error_msg_length ? "#{msg[0, max_error_msg_length]}..." : msg
       end

--- a/spec/sidekiq/undertaker_spec.rb
+++ b/spec/sidekiq/undertaker_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Sidekiq::Undertaker do
+  describe ".max_error_msg_length" do
+    around do |example|
+      memo = described_class.max_error_msg_length
+      example.run
+      described_class.max_error_msg_length = memo
+    end
+
+    it "returns the default max_error_msg_length" do
+      expect(described_class.max_error_msg_length).to eq(30)
+    end
+
+    it "updates the max_error_msg_length" do
+      new_value = 99
+      expect { described_class.max_error_msg_length = new_value }
+        .to change(described_class, :max_error_msg_length)
+        .from(30).to(new_value)
+
+      expect(described_class.max_error_msg_length).to eq(new_value)
+    end
+  end
+end


### PR DESCRIPTION
I finally took some time to make this configurable, as we discussed.

The max error message length can be configured e.g in an initializer via 
`Sidekiq::Undertaker.max_error_msg_length = 150`

Tested it locally and it worked fine (with default and with configuration).

Please let me know what you think about it, thanks!